### PR TITLE
RUMM-1188 Use additional config

### DIFF
--- a/DatadogSDKBridge.podspec
+++ b/DatadogSDKBridge.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
   s.source_files = 'DatadogSDKBridge/Classes/**/*'
-  s.dependency 'DatadogSDK', '~> 1.5.1'
+  s.dependency 'DatadogSDK', '~> 1.5.2'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'DatadogSDKBridge/Tests/*.swift'

--- a/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
@@ -56,6 +56,9 @@ internal class DdSdkImplementation: DdSdk {
         default:
             ddConfigBuilder.set(endpoint: .us)
         }
+        
+        let additionalConfig: [String: Any] = configuration.additionalConfig as? [String:Any] ?? [:]
+        ddConfigBuilder.set(additionalConfiguration: additionalConfig)
 
         return ddConfigBuilder.build()
     }

--- a/DatadogSDKBridge/Tests/DdSdkTests.swift
+++ b/DatadogSDKBridge/Tests/DdSdkTests.swift
@@ -60,6 +60,15 @@ internal class DdSdkTests: XCTestCase {
         
         XCTAssertEqual(ddConfig.datadogEndpoint, Datadog.Configuration.DatadogEndpoint.gov)
     }
+    
+    func testBuildConfigurationAdditionalConfig() {
+        let configuration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, additionalConfig: ["foo": "test", "bar": 42])
+        
+        let ddConfig = DdSdkImplementation().buildConfiguration(configuration: configuration)
+        
+        XCTAssertEqual(ddConfig.additionalConfiguration["foo"] as! String, "test")
+        XCTAssertEqual(ddConfig.additionalConfiguration["bar"] as! Int, 42)
+    }
 
     func testSettingUserInfo() throws {
         let bridge = DdSdkImplementation()


### PR DESCRIPTION
Forwards the `additionalConfiguration` dictionary to the native SDK.

This will among other things allow CrossPlatforms SDKs to set a custom `source` tag for data.