### PR TITLE
RUMM-1343: Support external timings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+.DS_Store

--- a/DatadogSDKBridge.podspec
+++ b/DatadogSDKBridge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'DatadogSDKBridge'
-  s.version          = '0.4.0'
+  s.version          = '0.4.1'
   s.summary          = 'Datadog iOS SDK Bridge for cross-platform integrations.'
 
   s.homepage         = 'https://github.com/DataDog/dd-bridge-ios'
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
   s.source_files = 'DatadogSDKBridge/Classes/**/*'
-  s.dependency 'DatadogSDK', '~> 1.5.2'
+  s.dependency 'DatadogSDK', '~> 1.6.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'DatadogSDKBridge/Tests/*.swift'

--- a/DatadogSDKBridge.podspec.src
+++ b/DatadogSDKBridge.podspec.src
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
   s.source_files = 'DatadogSDKBridge/Classes/**/*'
-  s.dependency 'DatadogSDK', '~> 1.5.1'
+  s.dependency 'DatadogSDK', '~> 1.6.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'DatadogSDKBridge/Tests/*.swift'

--- a/DatadogSDKBridge/Classes/Implementation/DdRumImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdRumImplementation.swift
@@ -9,7 +9,7 @@ import Datadog
 
 extension DDRUMMonitor: NativeRUM { }
 internal protocol NativeRUM {
-    func startView(key: String, path: String?, attributes: [String: Encodable])
+    func startView(key: String, name: String?, attributes: [String: Encodable])
     func stopView(key: String, attributes: [String: Encodable])
     func addError(message: String, source: RUMErrorSource, stack: String?, attributes: [String: Encodable], file: StaticString?, line: UInt?)
     func startResourceLoading(resourceKey: String, httpMethod: RUMMethod, urlString: String, attributes: [String: Encodable])
@@ -109,7 +109,7 @@ internal class DdRumImplementation: DdRum {
     }
 
     func startView(key: NSString, name: NSString, timestampMs: Int64, context: NSDictionary) {
-        nativeRUM.startView(key: key as String, path: name as String, attributes: attributes(from: context, with: timestampMs))
+        nativeRUM.startView(key: key as String, name: name as String, attributes: attributes(from: context, with: timestampMs))
     }
 
     func stopView(key: NSString, timestampMs: Int64, context: NSDictionary) {

--- a/DatadogSDKBridge/Tests/DdRumTests.swift
+++ b/DatadogSDKBridge/Tests/DdRumTests.swift
@@ -192,7 +192,7 @@ internal class DdRumTests: XCTestCase {
     }
 
     private func nanoTimeToDate(timestampNs: Int64) -> Date {
-        return Date(timeIntervalSince1970: TimeInterval(Double(timestampNs) / 1_000_000_000))
+        return Date(timeIntervalSince1970: TimeInterval(fromNs: timestampNs))
     }
 }
 

--- a/DatadogSDKBridge/Tests/DdRumTests.swift
+++ b/DatadogSDKBridge/Tests/DdRumTests.swift
@@ -114,6 +114,63 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
     }
 
+    func testStopResourceWithExternalTimings() throws {
+        let context: NSDictionary = [
+            "foo": 123,
+            "_dd.resource_timings": [
+                "fetch": [
+                    "startTime": 0,
+                    "duration": 13
+                ],
+                "redirect": [
+                    "startTime": 1,
+                    "duration": 1
+                ],
+                "dns": [
+                    "startTime": 3,
+                    "duration": 1
+                ],
+                "connect": [
+                    "startTime": 5,
+                    "duration": 1
+                ],
+                "ssl": [
+                    "startTime": 7,
+                    "duration": 1
+                ],
+                "firstByte": [
+                    "startTime": 9,
+                    "duration": 1
+                ],
+                "download": [
+                    "startTime": 11,
+                    "duration": 1
+                ]
+            ]
+        ]
+
+        rum.stopResource(key: "resource key", statusCode: 999, kind: "xhr", timestampMs: randomTimestamp, context: context)
+
+        XCTAssertEqual(mockNativeRUM.calledMethods.count, 2)
+
+        XCTAssertEqual(mockNativeRUM.calledMethods.first, .addResourceMetrics(resourceKey: "resource key",
+                                                                              fetch: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 0), end: nanoTimeToDate(timestampNs: 13)),
+                                                                              redirection: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 1), end: nanoTimeToDate(timestampNs: 2)),
+                                                                              dns: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 3), end: nanoTimeToDate(timestampNs: 4)),
+                                                                              connect: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 5), end: nanoTimeToDate(timestampNs: 6)),
+                                                                              ssl: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 7), end: nanoTimeToDate(timestampNs: 8)),
+                                                                              firstByte: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 9), end: nanoTimeToDate(timestampNs: 10)),
+                                                                              download: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 11), end: nanoTimeToDate(timestampNs: 12)),
+                                                                              responseSize: nil))
+
+        XCTAssertEqual(mockNativeRUM.calledMethods.last, .stopResourceLoading(resourceKey: "resource key", statusCode: 999, kind: .xhr))
+        XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 2)
+        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttribtutes.count, 2)
+        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+    }
+
     func testAddError() throws {
         rum.addError(message: "error message", source: "webview", stacktrace: "error trace", timestampMs: randomTimestamp, context: ["foo": 123])
 
@@ -133,9 +190,18 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .addTiming(name: "timing"))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 0)
     }
+
+    private func nanoTimeToDate(timestampNs: Int64) -> Date {
+        return Date(timeIntervalSince1970: TimeInterval(Double(timestampNs) / 1_000_000_000))
+    }
 }
 
 private class MockNativeRUM: NativeRUM {
+    struct Interval: Equatable {
+        let start: Date?
+        let end: Date?
+    }
+
     enum CalledMethod: Equatable {
         case startView(key: String, path: String?)
         case stopView(key: String)
@@ -146,6 +212,15 @@ private class MockNativeRUM: NativeRUM {
         case stopUserAction(type: RUMUserActionType, name: String?)
         case addUserAction(type: RUMUserActionType, name: String)
         case addTiming(name: String)
+        case addResourceMetrics(resourceKey: String,
+                                fetch: Interval,
+                                redirection: Interval,
+                                dns: Interval,
+                                connect: Interval,
+                                ssl: Interval,
+                                firstByte: Interval,
+                                download: Interval,
+                                responseSize: Int64?)
     }
 
     private(set) var calledMethods = [CalledMethod]()
@@ -187,6 +262,33 @@ private class MockNativeRUM: NativeRUM {
     }
     func addTiming(name: String) {
         calledMethods.append(.addTiming(name: name))
+    }
+    func addResourceMetrics(
+        resourceKey: String,
+        fetch: (start: Date, end: Date),
+        redirection: (start: Date, end: Date)?,
+        dns: (start: Date, end: Date)?,
+        connect: (start: Date, end: Date)?,
+        ssl: (start: Date, end: Date)?,
+        firstByte: (start: Date, end: Date)?,
+        download: (start: Date, end: Date)?,
+        responseSize: Int64?,
+        attributes: [AttributeKey: AttributeValue]
+    ) {
+        calledMethods.append(
+            .addResourceMetrics(
+                resourceKey: resourceKey,
+                fetch: Interval(start: fetch.start, end: fetch.end),
+                redirection: Interval(start: redirection?.start, end: redirection?.end),
+                dns: Interval(start: dns?.start, end: dns?.end),
+                connect: Interval(start: connect?.start, end: connect?.end),
+                ssl: Interval(start: ssl?.start, end: ssl?.end),
+                firstByte: Interval(start: firstByte?.start, end: firstByte?.end),
+                download: Interval(start: download?.start, end: download?.end),
+                responseSize: responseSize
+            )
+        )
+        receivedAttributes.append(attributes as! [String: AnyEncodable])
     }
     // swiftlint:enable force_cast
 }

--- a/DatadogSDKBridge/Tests/DdRumTests.swift
+++ b/DatadogSDKBridge/Tests/DdRumTests.swift
@@ -27,7 +27,7 @@ internal class DdRumTests: XCTestCase {
         rum.startView(key: "view key", name: "view name", timestampMs: randomTimestamp, context: ["foo": 123])
 
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 1)
-        XCTAssertEqual(mockNativeRUM.calledMethods.last, .startView(key: "view key", path: "view name"))
+        XCTAssertEqual(mockNativeRUM.calledMethods.last, .startView(key: "view key", name: "view name"))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
@@ -203,7 +203,7 @@ private class MockNativeRUM: NativeRUM {
     }
 
     enum CalledMethod: Equatable {
-        case startView(key: String, path: String?)
+        case startView(key: String, name: String?)
         case stopView(key: String)
         case addError(message: String, source: RUMErrorSource, stack: String?)
         case startResourceLoading(resourceKey: String, httpMethod: RUMMethod, urlString: String)
@@ -227,8 +227,8 @@ private class MockNativeRUM: NativeRUM {
     private(set) var receivedAttributes = [[String: AnyEncodable]]()
 
     // swiftlint:disable force_cast
-    func startView(key: String, path: String?, attributes: [String: Encodable]) {
-        calledMethods.append(.startView(key: key, path: path))
+    func startView(key: String, name: String?, attributes: [String: Encodable]) {
+        calledMethods.append(.startView(key: key, name: name))
         receivedAttributes.append(attributes as! [String: AnyEncodable])
     }
     func stopView(key: String, attributes: [String: Encodable]) {

--- a/Example/DatadogSDKBridge.xcodeproj/xcshareddata/xcschemes/DatadogSDKBridge-Example.xcscheme
+++ b/Example/DatadogSDKBridge.xcodeproj/xcshareddata/xcschemes/DatadogSDKBridge-Example.xcscheme
@@ -40,8 +40,16 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "DatadogSDKBridge_Example.app"
+            BlueprintName = "DatadogSDKBridge_Example"
+            ReferencedContainer = "container:DatadogSDKBridge.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,23 +62,11 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
-            BuildableName = "DatadogSDKBridge_Example.app"
-            BlueprintName = "DatadogSDKBridge_Example"
-            ReferencedContainer = "container:DatadogSDKBridge.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -87,8 +83,6 @@
             ReferencedContainer = "container:DatadogSDKBridge.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - DatadogSDK (1.5.2):
-    - Kronos (~> 4.1)
-  - DatadogSDKBridge (0.4.0):
-    - DatadogSDK (~> 1.5.2)
-  - DatadogSDKBridge/Tests (0.4.0):
-    - DatadogSDK (~> 1.5.2)
+  - DatadogSDK (1.6.0):
+    - Kronos (~> 4.2)
+  - DatadogSDKBridge (0.4.1):
+    - DatadogSDK (~> 1.6.0)
+  - DatadogSDKBridge/Tests (0.4.1):
+    - DatadogSDK (~> 1.6.0)
   - Kronos (4.2.1)
 
 DEPENDENCIES:
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  DatadogSDK: 825d16f4724f8767e1f7b64b59e22a70d404b919
-  DatadogSDKBridge: 0d5a3800816e2b84940ceb9202453ede333d984d
+  DatadogSDK: f8d3b65909216d8f1a04c2ddb75a15784bf90fd2
+  DatadogSDKBridge: bcbfcd70b9852327c9ce4c0759c6a044f7207eae
   Kronos: 0ca73a1c00dc9a49a0bab4a6ed42f282562a7058
 
 PODFILE CHECKSUM: ba6317017d5ad4eab3b7cdb33eca856c819d2d6e


### PR DESCRIPTION
Add support of external timings. Draft for now since to be able to compile and write/run unit tests it is required to have a newer version of `DatadogSDK` which is not yet there.