### PR TITLE
RUMM-1318 tagged_commit workflow is added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,6 @@ bump:
 		echo Bumped version to $$version
 
 ship:
+		pod trunk me
 		pod spec lint --allow-warnings DatadogSDKBridge.podspec
 		pod trunk push --allow-warnings DatadogSDKBridge.podspec

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -18,6 +18,7 @@ workflows:
     - run_unit_tests
     - ship
     - _deploy_artifacts
+    - _notify_failure_on_slack
 
   _deploy_artifacts:
     description: |-
@@ -92,3 +93,24 @@ workflows:
             #!/usr/bin/env zsh
             set -e
             make ship
+
+  _notify_failure_on_slack:
+    description: |-
+        Notifies any (previous) workflow failure on Slack.
+        Should be used to notify failures for workflows which do not report back to GitHub check.
+    steps:
+    - slack:
+        is_always_run: true
+        run_if: .IsBuildFailed
+        inputs:
+        - channel: '#dd-sdk-ios'
+        - buttons: |-
+            See Bitrise log|${BITRISE_BUILD_URL}
+        - pretext: |-
+            ⚠️ Bitrise build failed.
+        - color_on_error: '#FF0000'
+        - author_name: ''
+        - message: ''
+        - message_on_error: 'dd-bridge-ios failed to ship!'
+        - icon_url: 'https://avatars.githubusercontent.com/t/3555052?s=128&v=4'
+        - webhook_url: '${SLACK_INCOMING_WEBHOOK_MOBILE_CI}'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,9 +6,17 @@ project_type: other
 workflows:
   run_from_repo:
     after_run:
-    - run_linter
     - make_dependencies
+    - run_linter
     - run_unit_tests
+    - _deploy_artifacts
+
+  tagged_commit:
+    after_run:
+    - make_dependencies
+    - run_linter
+    - run_unit_tests
+    - ship
     - _deploy_artifacts
 
   _deploy_artifacts:
@@ -72,3 +80,15 @@ workflows:
         - generate_code_coverage_files: 'no'
         - project_path: Example/Pods/Pods.xcodeproj
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogSDKBridge-unit-tests.html"
+
+  ship:
+    description: |-
+        Ships the tagged version to Cocoapods trunk and uploads binaries to Github.
+    steps:
+    - script:
+        title: Ship tagged version
+        inputs:
+        - content: |-
+            #!/usr/bin/env zsh
+            set -e
+            make ship


### PR DESCRIPTION
`tagged_commit` runs `make ship` in addition to regular `run_from_repo` steps.
`tagged_commit` is triggered by tags.