### PR TITLE
RUMM-1419: Make modules initialization safer - make logger, tracer and RUM lazy

### DIFF
--- a/DatadogSDKBridge/Classes/Implementation/DdLogsImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdLogsImplementation.swift
@@ -16,17 +16,18 @@ internal protocol NativeLogger {
 }
 
 public class DdLogsImplementation: DdLogs {
-    private let logger: NativeLogger
+    private lazy var logger: NativeLogger = loggerProvider()
+    private let loggerProvider: () -> NativeLogger
 
-    internal init(_ ddLogger: NativeLogger) {
-        self.logger = ddLogger
+    internal init(_ loggerProvider: @escaping () -> NativeLogger) {
+        self.loggerProvider = loggerProvider
     }
 
     public convenience init() {
         let builder = Logger.builder
             .sendNetworkInfo(true)
             .printLogsToConsole(true)
-        self.init(builder.build())
+        self.init { builder.build() }
     }
 
     public func debug(message: NSString, context: NSDictionary) {

--- a/DatadogSDKBridge/Classes/Implementation/DdRumImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdRumImplementation.swift
@@ -95,17 +95,18 @@ internal class DdRumImplementation: DdRum {
     internal static let firstByteTimingKey = "firstByte"
     internal static let downloadTimingKey = "download"
 
-    let nativeRUM: NativeRUM
+    lazy var nativeRUM: NativeRUM = rumProvider()
+    private let rumProvider: () -> NativeRUM
 
     private typealias UserAction = (type: RUMUserActionType, name: String?)
     private var ongoingUserActions = [UserAction]()
 
-    internal init(_ nativeRUM: NativeRUM) {
-        self.nativeRUM = nativeRUM
+    internal init(_ rumProvider: @escaping () -> NativeRUM) {
+        self.rumProvider = rumProvider
     }
 
     convenience init() {
-        self.init(RUMMonitor.initialize())
+        self.init { RUMMonitor.initialize() }
     }
 
     func startView(key: NSString, name: NSString, timestampMs: Int64, context: NSDictionary) {

--- a/DatadogSDKBridge/Classes/Implementation/DdTraceImpementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdTraceImpementation.swift
@@ -8,15 +8,16 @@ import Foundation
 import Datadog
 
 internal class DdTraceImpementation: DdTrace {
-    private let tracer: OTTracer
+    private lazy var tracer: OTTracer = tracerProvider()
+    private let tracerProvider: () -> OTTracer
     private(set) var spanDictionary = [NSString: OTSpan]()
 
-    internal init(_ ddTracer: OTTracer) {
-        self.tracer = ddTracer
+    internal init(_ tracerProvider: @escaping () -> OTTracer) {
+        self.tracerProvider = tracerProvider
     }
 
     convenience init() {
-        self.init(Tracer.initialize(configuration: Tracer.Configuration()))
+        self.init { Tracer.initialize(configuration: Tracer.Configuration()) }
     }
 
     func startSpan(operation: NSString, timestampMs: Int64, context: NSDictionary) -> NSString {

--- a/DatadogSDKBridge/Tests/DdLogsTests.swift
+++ b/DatadogSDKBridge/Tests/DdLogsTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 internal class DdLogsTests: XCTestCase {
     private let mockNativeLogger = MockNativeLogger()
-    private lazy var logger = DdLogsImplementation(mockNativeLogger)
+    private lazy var logger = DdLogsImplementation { self.mockNativeLogger }
 
     private let testMessage_swift: String = "message"
     private let testMessage_objc: NSString = "message"

--- a/DatadogSDKBridge/Tests/DdLogsTests.swift
+++ b/DatadogSDKBridge/Tests/DdLogsTests.swift
@@ -21,6 +21,22 @@ internal class DdLogsTests: XCTestCase {
         dictionary: ["key1": "value", 123: "value2"]
     )
 
+    func testItInitializesNativeLoggerOnlyOnce() {
+        // Given
+        let expectation = self.expectation(description: "Initialize logger once")
+
+        let logger = DdLogsImplementation { [unowned self] in
+            expectation.fulfill()
+            return self.mockNativeLogger
+        }
+
+        // When
+        (0..<10).forEach { _ in logger.debug(message: "foo", context: [:]) }
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
     func testLoggerDebug_validAttributes() throws {
         logger.debug(message: testMessage_objc, context: validTestAttributes_objc)
 

--- a/DatadogSDKBridge/Tests/DdRumTests.swift
+++ b/DatadogSDKBridge/Tests/DdRumTests.swift
@@ -19,6 +19,22 @@ internal class DdRumTests: XCTestCase {
         rum = DdRumImplementation { self.mockNativeRUM }
     }
 
+    func testItInitializesNativeRumOnlyOnce() {
+        // Given
+        let expectation = self.expectation(description: "Initialize RUM once")
+
+        let rum = DdRumImplementation { [unowned self] in
+            expectation.fulfill()
+            return self.mockNativeRUM
+        }
+
+        // When
+        (0..<10).forEach { _ in rum.addTiming(name: "foo") }
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
     func testInternalTimestampKeyValue() {
         XCTAssertEqual(DdRumImplementation.timestampKey, RUMAttribute.internalTimestamp)
     }

--- a/DatadogSDKBridge/Tests/DdRumTests.swift
+++ b/DatadogSDKBridge/Tests/DdRumTests.swift
@@ -16,7 +16,7 @@ internal class DdRumTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        rum = DdRumImplementation(mockNativeRUM)
+        rum = DdRumImplementation { self.mockNativeRUM }
     }
 
     func testInternalTimestampKeyValue() {

--- a/DatadogSDKBridge/Tests/DdTraceTests.swift
+++ b/DatadogSDKBridge/Tests/DdTraceTests.swift
@@ -25,6 +25,22 @@ internal class DdTraceTests: XCTestCase {
         ]
     )
 
+    func testItInitializesNativeTracerOnlyOnce() {
+        // Given
+        let expectation = self.expectation(description: "Initialize Tracer once")
+
+        let tracer = DdTraceImpementation { [unowned self] in
+            expectation.fulfill()
+            return self.mockNativeTracer
+        }
+
+        // When
+        (0..<10).forEach { _ in _ = tracer.startSpan(operation: "foo", timestampMs: 1_337, context: [:]) }
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
     func testStartingASpan() throws {
         let timestampInMiliseconds = Date.timeIntervalBetween1970AndReferenceDate * 1_000
         let spanID = tracer.startSpan(

--- a/DatadogSDKBridge/Tests/DdTraceTests.swift
+++ b/DatadogSDKBridge/Tests/DdTraceTests.swift
@@ -14,7 +14,7 @@ internal class DdTraceTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        tracer = DdTraceImpementation(mockNativeTracer)
+        tracer = DdTraceImpementation { self.mockNativeTracer }
     }
 
     private let testTags = NSDictionary(


### PR DESCRIPTION
This change adds additional safety measure: now we are going to init logger, tracer and RUM in a lazy way, to be less dependent on the native modules loading mechanism, because these components require SDK initialization first.