### PR TITLE
RUMM-1445: Fix timestamp precision loss in finishSpan call

### DIFF
--- a/DatadogSDKBridge/Classes/Implementation/DdTraceImpementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdTraceImpementation.swift
@@ -43,8 +43,8 @@ internal class DdTraceImpementation: DdTrace {
 
         if let span = optionalSpan {
             set(tags: context, to: span)
-            let timestampInSeconds = TimeInterval(timestampMs / 1_000)
-            span.finish(at: Date(timeIntervalSince1970: timestampInSeconds))
+            let timeIntervalSince1970: TimeInterval = Double(timestampMs) / 1_000
+            span.finish(at: Date(timeIntervalSince1970: timeIntervalSince1970))
         }
     }
 

--- a/DatadogSDKBridge/Tests/DdTraceTests.swift
+++ b/DatadogSDKBridge/Tests/DdTraceTests.swift
@@ -26,10 +26,10 @@ internal class DdTraceTests: XCTestCase {
     )
 
     func testStartingASpan() throws {
-        let timestampInMiliseconds = Date.timeIntervalBetween1970AndReferenceDate * 1_000
+        let timestampInMilliseconds = Date.timeIntervalBetween1970AndReferenceDate * 1_000
         let spanID = tracer.startSpan(
             operation: "test_span",
-            timestampMs: Int64(timestampInMiliseconds),
+            timestampMs: Int64(timestampInMilliseconds),
             context: testTags
         )
 
@@ -47,7 +47,7 @@ internal class DdTraceTests: XCTestCase {
     }
 
     func testFinishingASpan() throws {
-        let startDate = Date(timeIntervalSinceReferenceDate: 0.0)
+        let startDate = Date(timeIntervalSinceReferenceDate: 42.042)
         let timestampMs = Int64(startDate.timeIntervalSince1970 * 1_000)
         let spanID = tracer.startSpan(
             operation: "test_span",
@@ -59,14 +59,18 @@ internal class DdTraceTests: XCTestCase {
         let startedSpan = try XCTUnwrap(mockNativeTracer.startedSpans.last)
         XCTAssertEqual(startedSpan.finishTime, MockSpan.unfinished)
 
-        let spanDuration: TimeInterval = 10.0
-        let spanDurationMs = Int64(spanDuration) * 1_000
+        let spanDuration: TimeInterval = 10.042
+        let spanDurationMs = Int64(spanDuration * 1_000)
         let finishTimestampMs = timestampMs + spanDurationMs
         let finishingContext = NSDictionary(dictionary: ["last_key": "last_value"])
         tracer.finishSpan(spanId: spanID, timestampMs: finishTimestampMs, context: finishingContext)
 
         XCTAssertEqual(Array(tracer.spanDictionary.keys), [])
-        XCTAssertEqual(startedSpan.finishTime, startDate + spanDuration)
+        XCTAssertEqual(
+            startedSpan.finishTime!.timeIntervalSince1970, // swiftlint:disable:this force_unwrapping
+            (startDate + spanDuration).timeIntervalSince1970,
+            accuracy: 0.001
+        )
         let tags = try XCTUnwrap(startedSpan.tags as? [String: AnyEncodable])
         XCTAssertEqual(tags["last_key"]?.value as? String, "last_value")
     }


### PR DESCRIPTION
Milliseconds were lost during the conversion to seconds, because of the integer division.