### PR TITLE
Bumped version to 0.4.3

### DIFF
--- a/DatadogSDKBridge.podspec
+++ b/DatadogSDKBridge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'DatadogSDKBridge'
-  s.version          = '0.4.1'
+  s.version          = '0.4.3'
   s.summary          = 'Datadog iOS SDK Bridge for cross-platform integrations.'
 
   s.homepage         = 'https://github.com/DataDog/dd-bridge-ios'


### PR DESCRIPTION
To be merged only after #18. Going to skip `0.4.2` to be in sync with https://github.com/DataDog/dd-bridge-android/pull/26