### PR TITLE
Specify Swift version in podspec

### DIFF
--- a/DatadogSDKBridge.podspec.src
+++ b/DatadogSDKBridge.podspec.src
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://www.datadoghq.com"
   s.social_media_url   = "https://twitter.com/datadoghq"
 
+  s.swift_versions        = ['5.1']
   s.ios.deployment_target = '11.0'
   s.source_files = 'DatadogSDKBridge/Classes/**/*'
   s.dependency 'DatadogSDK', '~> 1.6.0'


### PR DESCRIPTION
Otherwise there is a following warning during the `ship` stage:

```
    - WARN  | [iOS] swift: The validator used Swift `4.0` by default because no Swift version was specified. To specify a Swift version during validation, add the `swift_versions` attribute in your podspec. Note that usage of a `.swift-version` file is now deprecated.
```