### PR TITLE
RUMM-1403: Fix logs bundling with RUM

### DIFF
--- a/DatadogSDKBridge.podspec
+++ b/DatadogSDKBridge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'DatadogSDKBridge'
-  s.version          = '0.4.3'
+  s.version          = '0.4.4'
   s.summary          = 'Datadog iOS SDK Bridge for cross-platform integrations.'
 
   s.homepage         = 'https://github.com/DataDog/dd-bridge-ios'
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://www.datadoghq.com"
   s.social_media_url   = "https://twitter.com/datadoghq"
 
+  s.swift_versions        = ['5.1']
   s.ios.deployment_target = '11.0'
   s.source_files = 'DatadogSDKBridge/Classes/**/*'
   s.dependency 'DatadogSDK', '~> 1.6.0'

--- a/DatadogSDKBridge/Classes/Implementation/DdRumImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdRumImplementation.swift
@@ -106,7 +106,7 @@ internal class DdRumImplementation: DdRum {
     }
 
     convenience init() {
-        self.init { RUMMonitor.initialize() }
+        self.init { Global.rum }
     }
 
     func startView(key: NSString, name: NSString, timestampMs: Int64, context: NSDictionary) {

--- a/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
@@ -12,6 +12,8 @@ internal class DdSdkImplementation: DdSdk {
         let ddConfig = buildConfiguration(configuration: configuration)
         let consent = buildTrackingConsent(consent: configuration.trackingConsent)
         Datadog.initialize(appContext: Datadog.AppContext(), trackingConsent: consent, configuration: ddConfig)
+
+        Global.rum = RUMMonitor.initialize()
     }
 
     func setAttributes(attributes: NSDictionary) {

--- a/DatadogSDKBridge/Tests/DdSdkTests.swift
+++ b/DatadogSDKBridge/Tests/DdSdkTests.swift
@@ -24,7 +24,7 @@ internal class DdSdkTests: XCTestCase {
 
         DdSdkImplementation().initialize(configuration: validConfiguration)
 
-        XCTAssertEqual(printedMessage, "🔥 Datadog SDK usage error: SDK is already initialized.")
+        XCTAssertEqual(printedMessage, "🔥 Datadog SDK usage error: SDK is already initialized.🔥 Datadog SDK usage error: The `RUMMonitor` instance was already created. Use existing `Global.rum` instead of initializing the `RUMMonitor` another time.")
 
         try Datadog.deinitializeOrThrow()
     }


### PR DESCRIPTION
This change fixes logs bundling with RUM (app, view, session info was missing in the logs) by registering RUM monitor in `Global` and then also using `Global` instance in `DdRum`.

This is probably a temporary workaround until we align on the `Global` usage in bridges considering modules initialization mechanism, because bundling with traces don't work as well (same issue - missing `Global`).