### PR TITLE
RUMM-1446 set SDK verbosity level from bridge

### DIFF
--- a/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
@@ -9,6 +9,8 @@ import Datadog
 
 internal class DdSdkImplementation: DdSdk {
     func initialize(configuration: DdSdkConfiguration) {
+        setVerbosityLevel(additionalConfig: configuration.additionalConfig)
+
         let ddConfig = buildConfiguration(configuration: configuration)
         let consent = buildTrackingConsent(consent: configuration.trackingConsent)
         Datadog.initialize(appContext: Datadog.AppContext(), trackingConsent: consent, configuration: ddConfig)
@@ -83,5 +85,21 @@ internal class DdSdkImplementation: DdSdk {
             trackingConsent = .pending
         }
         return trackingConsent
+    }
+
+    func setVerbosityLevel(additionalConfig: NSDictionary?) {
+        let verbosityLevel = (additionalConfig?["_dd.sdk_verbosity"]) as? NSString
+        switch verbosityLevel?.lowercased {
+        case "debug":
+            Datadog.verbosityLevel = .debug
+        case "info":
+            Datadog.verbosityLevel = .info
+        case "warn":
+            Datadog.verbosityLevel = .warn
+        case "error":
+            Datadog.verbosityLevel = .error
+        default:
+            Datadog.verbosityLevel = nil
+        }
     }
 }

--- a/DatadogSDKBridge/Tests/DdSdkTests.swift
+++ b/DatadogSDKBridge/Tests/DdSdkTests.swift
@@ -29,6 +29,66 @@ internal class DdSdkTests: XCTestCase {
         try Datadog.deinitializeOrThrow()
     }
 
+    func testSDKInitializationWithVerbosityDebug() throws {
+        let validConfiguration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: ["_dd.sdk_verbosity": "debug"])
+
+        DdSdkImplementation().initialize(configuration: validConfiguration)
+
+        XCTAssertEqual(Datadog.verbosityLevel, LogLevel.debug)
+
+        try Datadog.deinitializeOrThrow()
+    }
+
+    func testSDKInitializationWithVerbosityInfo() throws {
+        let validConfiguration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: ["_dd.sdk_verbosity": "info"])
+
+        DdSdkImplementation().initialize(configuration: validConfiguration)
+
+        XCTAssertEqual(Datadog.verbosityLevel, LogLevel.info)
+
+        try Datadog.deinitializeOrThrow()
+    }
+
+    func testSDKInitializationWithVerbosityWarn() throws {
+        let validConfiguration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: ["_dd.sdk_verbosity": "warn"])
+
+        DdSdkImplementation().initialize(configuration: validConfiguration)
+
+        XCTAssertEqual(Datadog.verbosityLevel, LogLevel.warn)
+
+        try Datadog.deinitializeOrThrow()
+    }
+
+    func testSDKInitializationWithVerbosityError() throws {
+        let validConfiguration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: ["_dd.sdk_verbosity": "error"])
+
+        DdSdkImplementation().initialize(configuration: validConfiguration)
+
+        XCTAssertEqual(Datadog.verbosityLevel, LogLevel.error)
+
+        try Datadog.deinitializeOrThrow()
+    }
+
+    func testSDKInitializationWithVerbosityNil() throws {
+        let validConfiguration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: nil)
+
+        DdSdkImplementation().initialize(configuration: validConfiguration)
+
+        XCTAssertNil(Datadog.verbosityLevel)
+
+        try Datadog.deinitializeOrThrow()
+    }
+
+    func testSDKInitializationWithVerbosityUnknown() throws {
+        let validConfiguration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: ["_dd.sdk_verbosity": "foo"])
+
+        DdSdkImplementation().initialize(configuration: validConfiguration)
+
+        XCTAssertNil(Datadog.verbosityLevel)
+
+        try Datadog.deinitializeOrThrow()
+    }
+
     func testBuildConfigurationDefaultEndpoint() {
         let configuration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: nil)
 


### PR DESCRIPTION
Use the `_dd.sdk_verbosity` key in the `additionalConfig` dictionary to enable/disable `Datadog.verbosityLevel`