### PR TITLE
RUMM-1430 let bridge enable/disable native view tracking

### DIFF
--- a/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
@@ -69,6 +69,11 @@ internal class DdSdkImplementation: DdSdk {
         let additionalConfig: [String: Any] = configuration.additionalConfig as? [String: Any] ?? [:]
         _ = ddConfigBuilder.set(additionalConfiguration: additionalConfig)
 
+        let enableViewTracking = additionalConfig["_dd.native_view_tracking"] as? Bool
+        if enableViewTracking == true {
+            _ = ddConfigBuilder.trackUIKitRUMViews()
+        }
+
         return ddConfigBuilder.build()
     }
 

--- a/DatadogSDKBridge/Tests/DdSdkTests.swift
+++ b/DatadogSDKBridge/Tests/DdSdkTests.swift
@@ -29,6 +29,30 @@ internal class DdSdkTests: XCTestCase {
         try Datadog.deinitializeOrThrow()
     }
 
+    func testBuildConfigurationNoUIKitByDefault() {
+        let configuration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: nil)
+
+        let ddConfig = DdSdkImplementation().buildConfiguration(configuration: configuration)
+
+        XCTAssertNil(ddConfig.rumUIKitViewsPredicate)
+    }
+
+    func testBuildConfigurationUIKitTrackingDisabled() {
+        let configuration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: ["_dd.native_view_tracking": false])
+
+        let ddConfig = DdSdkImplementation().buildConfiguration(configuration: configuration)
+
+        XCTAssertNil(ddConfig.rumUIKitViewsPredicate)
+    }
+
+    func testBuildConfigurationUIKitTrackingEnabled() {
+        let configuration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: ["_dd.native_view_tracking": true])
+
+        let ddConfig = DdSdkImplementation().buildConfiguration(configuration: configuration)
+
+        XCTAssertNotNil(ddConfig.rumUIKitViewsPredicate)
+    }
+
     func testSDKInitializationWithVerbosityDebug() throws {
         let validConfiguration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: ["_dd.sdk_verbosity": "debug"])
 


### PR DESCRIPTION

Let customer enable or disable native view tracking (UIViewController) from a cross platform SDK. 