### PR TITLE
RUMM-1434 Fix passing internal `_dd.` attributes to native SDK

### DIFF
--- a/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
@@ -25,9 +25,9 @@ internal class DdSdkImplementation: DdSdk {
 
     func setUser(user: NSDictionary) {
         var castedUser = castAttributesToSwift(user)
-        let id = (castedUser.removeValue(forKey: "id") as? AnyEncodable)?.value as? String
-        let name = (castedUser.removeValue(forKey: "name") as? AnyEncodable)?.value as? String
-        let email = (castedUser.removeValue(forKey: "email") as? AnyEncodable)?.value as? String
+        let id = castedUser.removeValue(forKey: "id") as? String
+        let name = castedUser.removeValue(forKey: "name") as? String
+        let email = castedUser.removeValue(forKey: "email") as? String
         let extraInfo: [String: Encodable] = castedUser // everything what's left is an `extraInfo`
 
         Datadog.setUserInfo(id: id, name: name, email: email, extraInfo: extraInfo)

--- a/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
@@ -25,9 +25,9 @@ internal class DdSdkImplementation: DdSdk {
 
     func setUser(user: NSDictionary) {
         var castedUser = castAttributesToSwift(user)
-        let id = castedUser.removeValue(forKey: "id")?.value as? String
-        let name = castedUser.removeValue(forKey: "name")?.value as? String
-        let email = castedUser.removeValue(forKey: "email")?.value as? String
+        let id = (castedUser.removeValue(forKey: "id") as? AnyEncodable)?.value as? String
+        let name = (castedUser.removeValue(forKey: "name") as? AnyEncodable)?.value as? String
+        let email = (castedUser.removeValue(forKey: "email") as? AnyEncodable)?.value as? String
         let extraInfo: [String: Encodable] = castedUser // everything what's left is an `extraInfo`
 
         Datadog.setUserInfo(id: id, name: name, email: email, extraInfo: extraInfo)

--- a/DatadogSDKBridge/Tests/AnyEncodableTests.swift
+++ b/DatadogSDKBridge/Tests/AnyEncodableTests.swift
@@ -8,7 +8,69 @@ import XCTest
 @testable import DatadogSDKBridge
 
 internal class AnyEncodableTests: XCTestCase {
-    func testWhenWrappingAnyTypeUsingAnyEncodable_thenItGetsEncodedInExpectedFormat() throws {
+    // MARK: - Casting attributes
+
+    func testWhenCastingUserAttributes_thenItWrapsThemInAnyEncodableContainer() throws {
+        // Given
+        let userAttributes = NSDictionary(
+            dictionary: [
+                "array": [1, 2, 3],
+                "boolean": true,
+                "date": Date(timeIntervalSince1970: 123),
+                "double": 3.141_592_653_589_793,
+                "integer": 42,
+                "nested": [
+                    "a": "alpha",
+                    "b": "bravo",
+                    "c": "charlie"
+                ],
+                "null": NSNull(),
+                "string": "string",
+                "url": NSURL(string: "https://datadoghq.com")!, // swiftlint:disable:this force_unwrapping
+            ]
+        )
+
+        // When
+        let castedAttributes = castAttributesToSwift(userAttributes)
+
+        // Then
+        XCTAssertEqual(castedAttributes.count, userAttributes.count)
+        XCTAssertEqual((castedAttributes["array"] as? AnyEncodable)?.value as? [Int], [1, 2, 3])
+        XCTAssertEqual((castedAttributes["boolean"] as? AnyEncodable)?.value as? Bool, true)
+        XCTAssertEqual((castedAttributes["date"] as? AnyEncodable)?.value as? Date, Date(timeIntervalSince1970: 123))
+        XCTAssertEqual((castedAttributes["double"] as? AnyEncodable)?.value as? Double, 3.141_592_653_589_793)
+        XCTAssertEqual((castedAttributes["integer"] as? AnyEncodable)?.value as? Int, 42)
+        XCTAssertEqual((castedAttributes["nested"] as? AnyEncodable)?.value as? [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
+        XCTAssertEqual((castedAttributes["null"] as? AnyEncodable)?.value as? NSNull, NSNull())
+        XCTAssertEqual((castedAttributes["string"] as? AnyEncodable)?.value as? String, "string")
+        XCTAssertEqual((castedAttributes["url"] as? AnyEncodable)?.value as? URL, URL(string: "https://datadoghq.com"))
+    }
+
+    func testWhenCastingInternalAttributes_thenItDoesNotEreaseItsType() throws {
+        // Given
+        let userAttributes = NSDictionary(
+            dictionary: [
+                "_dd.string": "string",
+                "_dd.boolean": true,
+                "_dd.double": 3.141_592_653_589_793,
+                "_dd.integer": 42,
+            ]
+        )
+
+        // When
+        let castedAttributes = castAttributesToSwift(userAttributes)
+
+        // Then
+        XCTAssertEqual(castedAttributes.count, userAttributes.count)
+        XCTAssertEqual(castedAttributes["_dd.string"] as? String, "string")
+        XCTAssertEqual(castedAttributes["_dd.boolean"] as? Int64, 1, "Boolean value must be casted to `Int64`")
+        XCTAssertEqual(castedAttributes["_dd.double"] as? Double, 3.141_592_653_589_793)
+        XCTAssertEqual(castedAttributes["_dd.integer"] as? Int64, 42)
+    }
+
+    // MARK: - Encoding
+
+    func testWhenWrappingUserAttributesInAnyEncodable_thenTheyGetEncodedInExpectedFormat() throws {
         // Given
         let dictionary: [String: Any] = [
             "array": [1, 2, 3],

--- a/DatadogSDKBridge/Tests/DdRumTests.swift
+++ b/DatadogSDKBridge/Tests/DdRumTests.swift
@@ -47,8 +47,8 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStopView() throws {
@@ -59,8 +59,8 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStartAction() throws {
@@ -71,8 +71,8 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStopActionWithoutStarting() {
@@ -90,8 +90,8 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 2)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testAddAction() throws {
@@ -102,8 +102,8 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStartResource() throws {
@@ -114,8 +114,8 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStopResource() throws {
@@ -126,8 +126,8 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStopResourceWithExternalTimings() throws {
@@ -169,22 +169,48 @@ internal class DdRumTests: XCTestCase {
 
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 2)
 
-        XCTAssertEqual(mockNativeRUM.calledMethods.first, .addResourceMetrics(resourceKey: "resource key",
-                                                                              fetch: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 0), end: nanoTimeToDate(timestampNs: 13)),
-                                                                              redirection: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 1), end: nanoTimeToDate(timestampNs: 2)),
-                                                                              dns: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 3), end: nanoTimeToDate(timestampNs: 4)),
-                                                                              connect: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 5), end: nanoTimeToDate(timestampNs: 6)),
-                                                                              ssl: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 7), end: nanoTimeToDate(timestampNs: 8)),
-                                                                              firstByte: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 9), end: nanoTimeToDate(timestampNs: 10)),
-                                                                              download: MockNativeRUM.Interval(start: nanoTimeToDate(timestampNs: 11), end: nanoTimeToDate(timestampNs: 12)),
-                                                                              responseSize: nil))
+        XCTAssertEqual(
+            mockNativeRUM.calledMethods.first,
+            .addResourceMetrics(
+                resourceKey: "resource key",
+                fetch: MockNativeRUM.Interval(
+                    start: nanoTimeToDate(timestampNs: 0),
+                    end: nanoTimeToDate(timestampNs: 13)
+                ),
+                redirection: MockNativeRUM.Interval(
+                    start: nanoTimeToDate(timestampNs: 1),
+                    end: nanoTimeToDate(timestampNs: 2)
+                ),
+                dns: MockNativeRUM.Interval(
+                    start: nanoTimeToDate(timestampNs: 3),
+                    end: nanoTimeToDate(timestampNs: 4)
+                ),
+                connect: MockNativeRUM.Interval(
+                    start: nanoTimeToDate(timestampNs: 5),
+                    end: nanoTimeToDate(timestampNs: 6)
+                ),
+                ssl: MockNativeRUM.Interval(
+                    start: nanoTimeToDate(timestampNs: 7),
+                    end: nanoTimeToDate(timestampNs: 8)
+                ),
+                firstByte: MockNativeRUM.Interval(
+                    start: nanoTimeToDate(timestampNs: 9),
+                    end: nanoTimeToDate(timestampNs: 10)
+                ),
+                download: MockNativeRUM.Interval(
+                    start: nanoTimeToDate(timestampNs: 11),
+                    end: nanoTimeToDate(timestampNs: 12)
+                ),
+                responseSize: nil
+            )
+        )
 
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .stopResourceLoading(resourceKey: "resource key", statusCode: 999, kind: .xhr))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 2)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testAddError() throws {
@@ -195,8 +221,8 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
         let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
         XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual(lastAttribtutes["foo"]?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey]?.value as? Int64, randomTimestamp)
+        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
+        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testAddTiming() throws {
@@ -240,41 +266,41 @@ private class MockNativeRUM: NativeRUM {
     }
 
     private(set) var calledMethods = [CalledMethod]()
-    private(set) var receivedAttributes = [[String: AnyEncodable]]()
+    private(set) var receivedAttributes = [[String: Encodable]]()
 
     // swiftlint:disable force_cast
     func startView(key: String, name: String?, attributes: [String: Encodable]) {
         calledMethods.append(.startView(key: key, name: name))
-        receivedAttributes.append(attributes as! [String: AnyEncodable])
+        receivedAttributes.append(attributes)
     }
     func stopView(key: String, attributes: [String: Encodable]) {
         calledMethods.append(.stopView(key: key))
-        receivedAttributes.append(attributes as! [String: AnyEncodable])
+        receivedAttributes.append(attributes)
     }
     func addError(message: String, source: RUMErrorSource, stack: String?, attributes: [String: Encodable], file: StaticString?, line: UInt?) {
         calledMethods.append(.addError(message: message, source: source, stack: stack))
-        receivedAttributes.append(attributes as! [String: AnyEncodable])
+        receivedAttributes.append(attributes)
     }
 
     func startResourceLoading(resourceKey: String, httpMethod: RUMMethod, urlString: String, attributes: [String: Encodable]) {
         calledMethods.append(.startResourceLoading(resourceKey: resourceKey, httpMethod: httpMethod, urlString: urlString))
-        receivedAttributes.append(attributes as! [String: AnyEncodable])
+        receivedAttributes.append(attributes)
     }
     func stopResourceLoading(resourceKey: String, statusCode: Int?, kind: RUMResourceType, size: Int64?, attributes: [String: Encodable]) {
         calledMethods.append(.stopResourceLoading(resourceKey: resourceKey, statusCode: statusCode ?? 0, kind: kind))
-        receivedAttributes.append(attributes as! [String: AnyEncodable])
+        receivedAttributes.append(attributes)
     }
     func startUserAction(type: RUMUserActionType, name: String, attributes: [String: Encodable]) {
         calledMethods.append(.startUserAction(type: type, name: name))
-        receivedAttributes.append(attributes as! [String: AnyEncodable])
+        receivedAttributes.append(attributes)
     }
     func stopUserAction(type: RUMUserActionType, name: String?, attributes: [String: Encodable]) {
         calledMethods.append(.stopUserAction(type: type, name: name))
-        receivedAttributes.append(attributes as! [String: AnyEncodable])
+        receivedAttributes.append(attributes)
     }
     func addUserAction(type: RUMUserActionType, name: String, attributes: [String: Encodable]) {
         calledMethods.append(.addUserAction(type: type, name: name))
-        receivedAttributes.append(attributes as! [String: AnyEncodable])
+        receivedAttributes.append(attributes)
     }
     func addTiming(name: String) {
         calledMethods.append(.addTiming(name: name))
@@ -304,7 +330,7 @@ private class MockNativeRUM: NativeRUM {
                 responseSize: responseSize
             )
         )
-        receivedAttributes.append(attributes as! [String: AnyEncodable])
+        receivedAttributes.append(attributes)
     }
     // swiftlint:enable force_cast
 }

--- a/DatadogSDKBridge/Tests/DdRumTests.swift
+++ b/DatadogSDKBridge/Tests/DdRumTests.swift
@@ -45,10 +45,10 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 1)
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .startView(key: "view key", name: "view name"))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
-        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
-        XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
+        let lastAttributes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttributes.count, 2)
+        XCTAssertEqual(lastAttributes["foo"] as? Int64, 123)
+        XCTAssertEqual(lastAttributes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStopView() throws {
@@ -57,10 +57,10 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 1)
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .stopView(key: "view key"))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
-        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
-        XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
+        let lastAttributes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttributes.count, 2)
+        XCTAssertEqual(lastAttributes["foo"] as? Int64, 123)
+        XCTAssertEqual(lastAttributes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStartAction() throws {
@@ -69,10 +69,10 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 1)
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .startUserAction(type: .custom, name: "action name"))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
-        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
-        XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
+        let lastAttributes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttributes.count, 2)
+        XCTAssertEqual(lastAttributes["foo"] as? Int64, 123)
+        XCTAssertEqual(lastAttributes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStopActionWithoutStarting() {
@@ -88,10 +88,10 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 2)
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .stopUserAction(type: .custom, name: "action name"))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 2)
-        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
-        XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
+        let lastAttributes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttributes.count, 2)
+        XCTAssertEqual(lastAttributes["foo"] as? Int64, 123)
+        XCTAssertEqual(lastAttributes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testAddAction() throws {
@@ -100,10 +100,10 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 1)
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .addUserAction(type: .scroll, name: "action name"))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
-        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
-        XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
+        let lastAttributes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttributes.count, 2)
+        XCTAssertEqual(lastAttributes["foo"] as? Int64, 123)
+        XCTAssertEqual(lastAttributes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStartResource() throws {
@@ -112,10 +112,10 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 1)
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .startResourceLoading(resourceKey: "resource key", httpMethod: .put, urlString: "some/url/string"))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
-        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
-        XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
+        let lastAttributes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttributes.count, 2)
+        XCTAssertEqual(lastAttributes["foo"] as? Int64, 123)
+        XCTAssertEqual(lastAttributes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStopResource() throws {
@@ -124,10 +124,10 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 1)
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .stopResourceLoading(resourceKey: "resource key", statusCode: 999, kind: .xhr))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
-        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
-        XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
+        let lastAttributes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttributes.count, 2)
+        XCTAssertEqual(lastAttributes["foo"] as? Int64, 123)
+        XCTAssertEqual(lastAttributes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testStopResourceWithExternalTimings() throws {
@@ -207,10 +207,10 @@ internal class DdRumTests: XCTestCase {
 
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .stopResourceLoading(resourceKey: "resource key", statusCode: 999, kind: .xhr))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 2)
-        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
-        XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
+        let lastAttributes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttributes.count, 2)
+        XCTAssertEqual(lastAttributes["foo"] as? Int64, 123)
+        XCTAssertEqual(lastAttributes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testAddError() throws {
@@ -219,10 +219,10 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.calledMethods.count, 1)
         XCTAssertEqual(mockNativeRUM.calledMethods.last, .addError(message: "error message", source: .webview, stack: "error trace"))
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 1)
-        let lastAttribtutes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
-        XCTAssertEqual(lastAttribtutes.count, 2)
-        XCTAssertEqual((lastAttribtutes["foo"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual(lastAttribtutes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
+        let lastAttributes = try XCTUnwrap(mockNativeRUM.receivedAttributes.last)
+        XCTAssertEqual(lastAttributes.count, 2)
+        XCTAssertEqual(lastAttributes["foo"] as? Int64, 123)
+        XCTAssertEqual(lastAttributes[DdRumImplementation.timestampKey] as? Int64, randomTimestamp)
     }
 
     func testAddTiming() throws {

--- a/DatadogSDKBridge/Tests/DdSdkTests.swift
+++ b/DatadogSDKBridge/Tests/DdSdkTests.swift
@@ -93,9 +93,9 @@ internal class DdSdkTests: XCTestCase {
         XCTAssertEqual(receivedUserInfo.id, "abc-123")
         XCTAssertEqual(receivedUserInfo.name, "John Doe")
         XCTAssertEqual(receivedUserInfo.email, "john@doe.com")
-        XCTAssertEqual((receivedUserInfo.extraInfo["extra-info-1"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual((receivedUserInfo.extraInfo["extra-info-2"] as? AnyEncodable)?.value as? String, "abc")
-        XCTAssertEqual((receivedUserInfo.extraInfo["extra-info-3"] as? AnyEncodable)?.value as? Bool, true)
+        XCTAssertEqual(receivedUserInfo.extraInfo["extra-info-1"] as? Int64, 123)
+        XCTAssertEqual(receivedUserInfo.extraInfo["extra-info-2"] as? String, "abc")
+        XCTAssertEqual(receivedUserInfo.extraInfo["extra-info-3"] as? Bool, true)
 
         try Datadog.deinitializeOrThrow()
     }
@@ -117,9 +117,9 @@ internal class DdSdkTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual((rumMonitorMock.receivedAttributes["attribute-1"] as? AnyEncodable)?.value as? Int, 123)
-        XCTAssertEqual((rumMonitorMock.receivedAttributes["attribute-2"] as? AnyEncodable)?.value as? String, "abc")
-        XCTAssertEqual((rumMonitorMock.receivedAttributes["attribute-3"] as? AnyEncodable)?.value as? Bool, true)
+        XCTAssertEqual(rumMonitorMock.receivedAttributes["attribute-1"] as? Int64, 123)
+        XCTAssertEqual(rumMonitorMock.receivedAttributes["attribute-2"] as? String, "abc")
+        XCTAssertEqual(rumMonitorMock.receivedAttributes["attribute-3"] as? Bool, true)
 
         try Datadog.deinitializeOrThrow()
     }

--- a/DatadogSDKBridge/Tests/DdTraceTests.swift
+++ b/DatadogSDKBridge/Tests/DdTraceTests.swift
@@ -56,10 +56,10 @@ internal class DdTraceTests: XCTestCase {
         XCTAssertNil(startedSpan.parent)
         let startDate = Date(timeIntervalSince1970: Date.timeIntervalBetween1970AndReferenceDate)
         XCTAssertEqual(startedSpan.startTime, startDate)
-        let tags = try XCTUnwrap(startedSpan.tags as? [String: AnyEncodable])
-        XCTAssertEqual(tags["key_string"]?.value as? String, "value")
-        XCTAssertEqual(tags["key_number"]?.value as? Int, 123)
-        XCTAssertEqual(tags["key_bool"]?.value as? Bool, true)
+        let tags = try XCTUnwrap(startedSpan.tags)
+        XCTAssertEqual(tags["key_string"] as? String, "value")
+        XCTAssertEqual(tags["key_number"] as? Int64, 123)
+        XCTAssertEqual(tags["key_bool"] as? Bool, true)
     }
 
     func testFinishingASpan() throws {
@@ -87,8 +87,8 @@ internal class DdTraceTests: XCTestCase {
             (startDate + spanDuration).timeIntervalSince1970,
             accuracy: 0.001
         )
-        let tags = try XCTUnwrap(startedSpan.tags as? [String: AnyEncodable])
-        XCTAssertEqual(tags["last_key"]?.value as? String, "last_value")
+        let tags = try XCTUnwrap(startedSpan.tags)
+        XCTAssertEqual(tags["last_key"] as? String, "last_value")
     }
 
     func testFinishingInexistentSpan() {


### PR DESCRIPTION
🐞 This PR fixes a bug causing internal (`_dd.`) attributes not being readable in native SDK.

## The issue

Before this PR, we handled all `attributes` passed to the `bridge-ios` equally: their `Any` values were wrapped into `AnyEncodable` wrapper and passed to the native SDK.

This worked fine for user-defined attributes passed from RN SDK. If user added attribute `foo` with a value of `123`, that was wrapped into `AnyEncodable(123)`, and got encoded as `123` JSON element when serializing event payload in `dd-sdk-ios`.

This didn't work for internal attributes (`_dd.*`) passed from RN SDK. Each internal attribute created in RN was also wrapped into `AnyEncodable` container, which was erasing type information. Any `_dd.integer` of value `123` would become `AnyEncodable(123)`, leaving no way to get the `123` value back in `dd-sdk-ios`:
```swift
// in dd-sdk-ios

// This would return `nil` as `attributes["_dd.double"]` is `DatadogSDKBridge.AnyEncodable`
let value = attributes["_dd.double"] as? Double 

// This wouldn't compile as `DatadogSDKBridge.AnyEncodable` is not available in `dd-sdk-ios`
let value = (attributes["_dd.double"] as? DatadogSDKBridge.AnyEncodable).value as? Double 
```

## Fix

To fix this, I implemented two-phase casting of attributes received from RN:
* it first tries to cast attributes by preserving their type information (it tries to cast `Any` to known `Encodable` types),
* if the first casting fails, it falls back to preserving their encoded value (but it erases type information with `AnyEncodable`)

## Potential bugfix

To my understanding, [this logic](https://github.com/DataDog/dd-sdk-ios/blob/01e4c856971a8e530b1cd3d823e467895e9544c6/Sources/Datadog/RUMMonitor.swift#L620) in `dd-sdk-ios` was broken. This cast has no chance to succeed as stored type is `DatadogSDKBridge.AnyEncodable`, not `Int64`:
```swift
if let customTimestampInMiliseconds = combinedUserAttributes.removeValue(forKey: RUMAttribute.internalTimestamp) as? Int64 {
```

## Alternative solutions

I've considered following alternatives:
* Handling all attributes equally with no wrapping into `AnyEncodable` at all - this way is IMO not possible. We need `AnyEncodable` as it is the only way for transforming `[Any]` to `Encodable`. Arbitrary cast of `[Encodable] as? Encodable` does compile, but gives `nil`.
* Binding an arbitrary memory received in `dd-sdk-ios` to a mirror-type corresponding to `DatadogSDKBridge.AnyEncodable`. I think this could be possible to use (unsafe) raw memory APIs to cast the value passed between both modules and retrieve `Datadog.AnyEncodable` holding the value created in `bridge-ios`. This solution sounds very tricky and unsafe.