### PR TITLE
RUMM-1552: Support console error source type

### DIFF
--- a/DatadogSDKBridge.podspec
+++ b/DatadogSDKBridge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'DatadogSDKBridge'
-  s.version          = '0.4.5'
+  s.version          = '0.4.6'
   s.summary          = 'Datadog iOS SDK Bridge for cross-platform integrations.'
 
   s.homepage         = 'https://github.com/DataDog/dd-bridge-ios'
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.swift_versions        = ['5.1']
   s.ios.deployment_target = '11.0'
   s.source_files = 'DatadogSDKBridge/Classes/**/*'
-  s.dependency 'DatadogSDK', '~> 1.7.0-beta2'
+  s.dependency 'DatadogSDK', '~> 1.7.0-beta3'
 end

--- a/DatadogSDKBridge.podspec.src
+++ b/DatadogSDKBridge.podspec.src
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.swift_versions        = ['5.1']
   s.ios.deployment_target = '11.0'
   s.source_files = 'DatadogSDKBridge/Classes/**/*'
-  s.dependency 'DatadogSDK', '~> 1.7.0-beta2'
+  s.dependency 'DatadogSDK', '~> 1.7.0-beta3'
 end

--- a/DatadogSDKBridge/Classes/Implementation/DdRumImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdRumImplementation.swift
@@ -41,12 +41,13 @@ private extension RUMUserActionType {
     }
 }
 
-private extension RUMErrorSource {
+internal extension RUMErrorSource {
     init(from string: String) {
         switch string.lowercased() {
         case "source": self = .source
         case "network": self = .network
         case "webview": self = .webview
+        case "console": self = .console
         default: self = .custom
         }
     }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - DatadogSDK (1.7.0-beta2):
+  - DatadogSDK (1.7.0-beta3):
     - Kronos (~> 4.2)
-  - DatadogSDKBridge (0.4.5):
-    - DatadogSDK (~> 1.7.0-beta2)
+  - DatadogSDKBridge (0.4.6):
+    - DatadogSDK (~> 1.7.0-beta3)
   - Kronos (4.2.1)
 
 DEPENDENCIES:
@@ -18,8 +18,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  DatadogSDK: e8fcb05c1302e3eead6c3ea5e08a1dc7f167cc64
-  DatadogSDKBridge: b51f0d33db7530cf281a6e9f800b61eb2b738a11
+  DatadogSDK: 82aa63377d806379ad6b149e3a62b2e54e759ca3
+  DatadogSDKBridge: 15cf2a86b854c53026584a8c2ce5e350e237358f
   Kronos: 0ca73a1c00dc9a49a0bab4a6ed42f282562a7058
 
 PODFILE CHECKSUM: 0f230940dcc6685e1c6b3c7b34b7b2c618993c36

--- a/Example/Tests/DdRumTests.swift
+++ b/Example/Tests/DdRumTests.swift
@@ -233,6 +233,14 @@ internal class DdRumTests: XCTestCase {
         XCTAssertEqual(mockNativeRUM.receivedAttributes.count, 0)
     }
 
+    func testRumErrorSourceMapping() throws {
+        XCTAssertEqual(RUMErrorSource(from: "source"), RUMErrorSource.source)
+        XCTAssertEqual(RUMErrorSource(from: "network"), RUMErrorSource.network)
+        XCTAssertEqual(RUMErrorSource(from: "webview"), RUMErrorSource.webview)
+        XCTAssertEqual(RUMErrorSource(from: "console"), RUMErrorSource.console)
+        XCTAssertEqual(RUMErrorSource(from: "foobar"), RUMErrorSource.custom)
+    }
+
     private func nanoTimeToDate(timestampNs: Int64) -> Date {
         return Date(timeIntervalSince1970: TimeInterval(fromNs: timestampNs))
     }


### PR DESCRIPTION
This change adds support of `console` error source type, which is needed for the errors coming via `console.error` call in React Native to be consistent with Android bridge.