### PR TITLE
RUMM-1563 let customer define serviceName from additionalConfig

### DIFF
--- a/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
@@ -74,6 +74,10 @@ internal class DdSdkImplementation: DdSdk {
             _ = ddConfigBuilder.trackUIKitRUMViews()
         }
 
+        if let serviceName = additionalConfig["_dd.service_name"] as? String {
+            _ = ddConfigBuilder.set(serviceName: serviceName)
+        }
+
         return ddConfigBuilder.build()
     }
 

--- a/Example/Tests/DdSdkTests.swift
+++ b/Example/Tests/DdSdkTests.swift
@@ -156,6 +156,22 @@ internal class DdSdkTests: XCTestCase {
         // swiftlint:enable force_cast
     }
 
+    func testBuildConfigurationWithNilServiceNameByDefault() {
+        let configuration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: nil)
+
+        let ddConfig = DdSdkImplementation().buildConfiguration(configuration: configuration)
+
+        XCTAssertNil(ddConfig.serviceName)
+    }
+
+    func testBuildConfigurationWithServiceName() {
+        let configuration = DdSdkConfiguration(clientToken: "client-token", env: "env", applicationId: "app-id", nativeCrashReportEnabled: true, sampleRate: 75.0, site: nil, trackingConsent: "pending", additionalConfig: ["_dd.service_name": "com.example.app"])
+
+        let ddConfig = DdSdkImplementation().buildConfiguration(configuration: configuration)
+
+        XCTAssertEqual(ddConfig.serviceName, "com.example.app")
+    }
+
     func testSettingUserInfo() throws {
         let bridge = DdSdkImplementation()
         bridge.initialize(configuration: validConfiguration)


### PR DESCRIPTION
Let customers set a custom `serviceName` tag on their data using the additional configuration `_dd.service_name`