### PR TITLE
RUMM-1522: Use global attributes in Spans and Logs

### DIFF
--- a/DatadogSDKBridge/Classes/Implementation/DdLogsImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdLogsImplementation.swift
@@ -31,18 +31,22 @@ public class DdLogsImplementation: DdLogs {
     }
 
     public func debug(message: NSString, context: NSDictionary) {
-        logger.debug(message as String, error: nil, attributes: castAttributesToSwift(context))
+        let attributes = castAttributesToSwift(context).mergeWithGlobalAttributes()
+        logger.debug(message as String, error: nil, attributes: attributes)
     }
 
     public func info(message: NSString, context: NSDictionary) {
-        logger.info(message as String, error: nil, attributes: castAttributesToSwift(context))
+        let attributes = castAttributesToSwift(context).mergeWithGlobalAttributes()
+        logger.info(message as String, error: nil, attributes: attributes)
     }
 
     public func warn(message: NSString, context: NSDictionary) {
-        logger.warn(message as String, error: nil, attributes: castAttributesToSwift(context))
+        let attributes = castAttributesToSwift(context).mergeWithGlobalAttributes()
+        logger.warn(message as String, error: nil, attributes: attributes)
     }
 
     public func error(message: NSString, context: NSDictionary) {
-        logger.error(message as String, error: nil, attributes: castAttributesToSwift(context))
+        let attributes = castAttributesToSwift(context).mergeWithGlobalAttributes()
+        logger.error(message as String, error: nil, attributes: attributes)
     }
 }

--- a/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
@@ -22,6 +22,7 @@ internal class DdSdkImplementation: DdSdk {
         let castedAttributes = castAttributesToSwift(attributes)
         for (key, value) in castedAttributes {
             Global.rum.addAttribute(forKey: key, value: value)
+            GlobalState.addAttribute(forKey: key, value: value)
         }
     }
 

--- a/DatadogSDKBridge/Classes/Implementation/DdTraceImpementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdTraceImpementation.swift
@@ -29,7 +29,7 @@ internal class DdTraceImpementation: DdTrace {
         spanDictionary[id] = tracer.startSpan(
             operationName: operation as String,
             childOf: nil,
-            tags: castAttributesToSwift(context),
+            tags: castAttributesToSwift(context).mergeWithGlobalAttributes(),
             startTime: startDate
         )
         objc_sync_exit(self)
@@ -43,15 +43,14 @@ internal class DdTraceImpementation: DdTrace {
         objc_sync_exit(self)
 
         if let span = optionalSpan {
-            set(tags: context, to: span)
+            set(tags: castAttributesToSwift(context).mergeWithGlobalAttributes(), to: span)
             let timeIntervalSince1970: TimeInterval = Double(timestampMs) / 1_000
             span.finish(at: Date(timeIntervalSince1970: timeIntervalSince1970))
         }
     }
 
-    private func set(tags: NSDictionary, to span: OTSpan) {
-        let castedTags = castAttributesToSwift(tags)
-        for (key, value) in castedTags {
+    private func set(tags: [String: Encodable], to span: OTSpan) {
+        for (key, value) in tags {
             span.setTag(key: key, value: value)
         }
     }

--- a/DatadogSDKBridge/Classes/Implementation/GlobalState.swift
+++ b/DatadogSDKBridge/Classes/Implementation/GlobalState.swift
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2021 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct GlobalState {
+    /// Holds global attributes to be used with Logs and Traces, because they don't expose Global instances, unlike RUM
+    internal static var globalAttributes: [String: Encodable] = [:]
+
+    internal static func addAttribute(forKey: String, value: Encodable?) {
+        GlobalState.globalAttributes[forKey] = value
+    }
+
+    internal static func removeAttribute(key: String) {
+        GlobalState.globalAttributes.removeValue(forKey: key)
+    }
+}
+
+internal extension Dictionary where Key == String, Value == Encodable {
+    func mergeWithGlobalAttributes() -> [String: Encodable] {
+        // values of current attributes are more important than values of global attributes,
+        // because they are coming with a current call
+        return merging(GlobalState.globalAttributes) { current, _ in current }
+    }
+}

--- a/Example/DatadogSDKBridge.xcodeproj/project.pbxproj
+++ b/Example/DatadogSDKBridge.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		619506D026B93BD20046CB05 /* DdTraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619506CB26B93BD20046CB05 /* DdTraceTests.swift */; };
 		619506D126B93BD20046CB05 /* DdSdkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619506CC26B93BD20046CB05 /* DdSdkTests.swift */; };
 		619506D226B93BD20046CB05 /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619506CD26B93BD20046CB05 /* AnyEncodableTests.swift */; };
+		F68607F126FA06AD00A8F0B4 /* GlobalStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68607F026FA06AD00A8F0B4 /* GlobalStateTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		619506D326B93CB40046CB05 /* DatadogSDKBridge.podspec.src */ = {isa = PBXFileReference; lastKnownFileType = text; name = DatadogSDKBridge.podspec.src; path = ../DatadogSDKBridge.podspec.src; sourceTree = "<group>"; };
 		83C2E1CFBCA5873907FC6524 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		900ACF2E2DC14EEFE52A6E36 /* Pods-DatadogSDKBridge_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DatadogSDKBridge_Tests.release.xcconfig"; path = "Target Support Files/Pods-DatadogSDKBridge_Tests/Pods-DatadogSDKBridge_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		F68607F026FA06AD00A8F0B4 /* GlobalStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalStateTests.swift; sourceTree = "<group>"; };
 		F8332D35F5F99117CEFC7F28 /* Pods_DatadogSDKBridge_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DatadogSDKBridge_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -73,6 +75,7 @@
 				619506CC26B93BD20046CB05 /* DdSdkTests.swift */,
 				619506CB26B93BD20046CB05 /* DdTraceTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				F68607F026FA06AD00A8F0B4 /* GlobalStateTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -257,6 +260,7 @@
 				619506CF26B93BD20046CB05 /* DdLogsTests.swift in Sources */,
 				619506CE26B93BD20046CB05 /* DdRumTests.swift in Sources */,
 				619506D026B93BD20046CB05 /* DdTraceTests.swift in Sources */,
+				F68607F126FA06AD00A8F0B4 /* GlobalStateTests.swift in Sources */,
 				619506D226B93BD20046CB05 /* AnyEncodableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tests/DdLogsTests.swift
+++ b/Example/Tests/DdLogsTests.swift
@@ -21,6 +21,17 @@ internal class DdLogsTests: XCTestCase {
         dictionary: ["key1": "value", 123: "value2"]
     )
 
+    override func setUp() {
+        super.setUp()
+        GlobalState.addAttribute(forKey: "global-string", value: "foo")
+        GlobalState.addAttribute(forKey: "global-int", value: 42)
+    }
+
+    override func tearDown() {
+        GlobalState.globalAttributes.removeAll()
+        super.tearDown()
+    }
+
     func testItInitializesNativeLoggerOnlyOnce() {
         // Given
         let expectation = self.expectation(description: "Initialize logger once")
@@ -44,7 +55,10 @@ internal class DdLogsTests: XCTestCase {
         let received = try XCTUnwrap(mockNativeLogger.receivedMethodCalls.first)
         XCTAssertEqual(received.kind, .debug)
         XCTAssertEqual(received.message, testMessage_swift)
-        XCTAssertEqual(received.attributes?.keys, validTestAttributes_swift.keys)
+        XCTAssertEqual(
+            received.attributes?.keys,
+            validTestAttributes_swift.mergeWithGlobalAttributes().keys
+        )
     }
 
     func testLoggerInfo_validAttributes() throws {
@@ -54,7 +68,10 @@ internal class DdLogsTests: XCTestCase {
         let received = try XCTUnwrap(mockNativeLogger.receivedMethodCalls.first)
         XCTAssertEqual(received.kind, .info)
         XCTAssertEqual(received.message, testMessage_swift)
-        XCTAssertEqual(received.attributes?.keys, validTestAttributes_swift.keys)
+        XCTAssertEqual(
+            received.attributes?.keys,
+            validTestAttributes_swift.mergeWithGlobalAttributes().keys
+        )
     }
 
     func testLoggerWarn_validAttributes() throws {
@@ -64,7 +81,10 @@ internal class DdLogsTests: XCTestCase {
         let received = try XCTUnwrap(mockNativeLogger.receivedMethodCalls.first)
         XCTAssertEqual(received.kind, .warn)
         XCTAssertEqual(received.message, testMessage_swift)
-        XCTAssertEqual(received.attributes?.keys, validTestAttributes_swift.keys)
+        XCTAssertEqual(
+            received.attributes?.keys,
+            validTestAttributes_swift.mergeWithGlobalAttributes().keys
+        )
     }
 
     func testLoggerError_validAttributes() throws {
@@ -74,7 +94,10 @@ internal class DdLogsTests: XCTestCase {
         let received = try XCTUnwrap(mockNativeLogger.receivedMethodCalls.first)
         XCTAssertEqual(received.kind, .error)
         XCTAssertEqual(received.message, testMessage_swift)
-        XCTAssertEqual(received.attributes?.keys, validTestAttributes_swift.keys)
+        XCTAssertEqual(
+            received.attributes?.keys,
+            validTestAttributes_swift.mergeWithGlobalAttributes().keys
+        )
     }
 
     func testLoggerDebug_invalidAttributes() throws {
@@ -84,7 +107,10 @@ internal class DdLogsTests: XCTestCase {
         let received = try XCTUnwrap(mockNativeLogger.receivedMethodCalls.first)
         XCTAssertEqual(received.kind, .debug)
         XCTAssertEqual(received.message, testMessage_swift)
-        XCTAssertEqual(received.attributes?.keys, [:].keys)
+        XCTAssertEqual(
+            received.attributes?.keys,
+            GlobalState.globalAttributes.keys
+        )
     }
 
     func testLoggerInfo_invalidAttributes() throws {
@@ -94,7 +120,10 @@ internal class DdLogsTests: XCTestCase {
         let received = try XCTUnwrap(mockNativeLogger.receivedMethodCalls.first)
         XCTAssertEqual(received.kind, .info)
         XCTAssertEqual(received.message, testMessage_swift)
-        XCTAssertEqual(received.attributes?.keys, [:].keys)
+        XCTAssertEqual(
+            received.attributes?.keys,
+            GlobalState.globalAttributes.keys
+        )
     }
 
     func testLoggerWarn_invalidAttributes() throws {
@@ -104,7 +133,10 @@ internal class DdLogsTests: XCTestCase {
         let received = try XCTUnwrap(mockNativeLogger.receivedMethodCalls.first)
         XCTAssertEqual(received.kind, .warn)
         XCTAssertEqual(received.message, testMessage_swift)
-        XCTAssertEqual(received.attributes?.keys, [:].keys)
+        XCTAssertEqual(
+            received.attributes?.keys,
+            GlobalState.globalAttributes.keys
+        )
     }
 
     func testLoggerError_invalidAttributes() throws {
@@ -114,7 +146,10 @@ internal class DdLogsTests: XCTestCase {
         let received = try XCTUnwrap(mockNativeLogger.receivedMethodCalls.first)
         XCTAssertEqual(received.kind, .error)
         XCTAssertEqual(received.message, testMessage_swift)
-        XCTAssertEqual(received.attributes?.keys, [:].keys)
+        XCTAssertEqual(
+            received.attributes?.keys,
+            GlobalState.globalAttributes.keys
+        )
     }
 }
 

--- a/Example/Tests/DdSdkTests.swift
+++ b/Example/Tests/DdSdkTests.swift
@@ -221,6 +221,11 @@ internal class DdSdkTests: XCTestCase {
         XCTAssertEqual(rumMonitorMock.receivedAttributes["attribute-2"] as? String, "abc")
         XCTAssertEqual(rumMonitorMock.receivedAttributes["attribute-3"] as? Bool, true)
 
+        XCTAssertEqual(GlobalState.globalAttributes["attribute-1"] as? Int64, 123)
+        XCTAssertEqual(GlobalState.globalAttributes["attribute-2"] as? String, "abc")
+        XCTAssertEqual(GlobalState.globalAttributes["attribute-3"] as? Bool, true)
+
+        GlobalState.globalAttributes.removeAll()
         Datadog.flushAndDeinitialize()
     }
 

--- a/Example/Tests/DdTraceTests.swift
+++ b/Example/Tests/DdTraceTests.swift
@@ -15,6 +15,13 @@ internal class DdTraceTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         tracer = DdTraceImpementation { self.mockNativeTracer }
+        GlobalState.addAttribute(forKey: "global-string", value: "foo")
+        GlobalState.addAttribute(forKey: "global-int", value: 42)
+    }
+
+    override func tearDown() {
+        GlobalState.globalAttributes.removeAll()
+        super.tearDown()
     }
 
     private let testTags = NSDictionary(
@@ -60,6 +67,8 @@ internal class DdTraceTests: XCTestCase {
         XCTAssertEqual(tags["key_string"] as? String, "value")
         XCTAssertEqual(tags["key_number"] as? Int64, 123)
         XCTAssertEqual(tags["key_bool"] as? Bool, true)
+        XCTAssertEqual(tags["global-string"] as? String, "foo")
+        XCTAssertEqual(tags["global-int"] as? Int, 42)
     }
 
     func testFinishingASpan() throws {
@@ -89,6 +98,8 @@ internal class DdTraceTests: XCTestCase {
         )
         let tags = try XCTUnwrap(startedSpan.tags)
         XCTAssertEqual(tags["last_key"] as? String, "last_value")
+        XCTAssertEqual(tags["global-string"] as? String, "foo")
+        XCTAssertEqual(tags["global-int"] as? Int, 42)
     }
 
     func testFinishingInexistentSpan() {

--- a/Example/Tests/GlobalStateTests.swift
+++ b/Example/Tests/GlobalStateTests.swift
@@ -1,0 +1,68 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2021 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSDKBridge
+
+class GlobalStateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        GlobalState.globalAttributes.removeAll()
+    }
+
+    override func tearDown() {
+        GlobalState.globalAttributes.removeAll()
+        super.tearDown()
+    }
+
+    func testAttributeAdded() throws {
+        GlobalState.addAttribute(forKey: "foo", value: "bar")
+        GlobalState.addAttribute(forKey: "int", value: 42)
+
+        XCTAssertEqual(GlobalState.globalAttributes["foo"] as? String, "bar")
+        XCTAssertEqual(GlobalState.globalAttributes["int"] as? Int, 42)
+    }
+
+    func testAttributeRemoved() throws {
+        GlobalState.addAttribute(forKey: "foo", value: "bar")
+        GlobalState.removeAttribute(key: "foo")
+
+        XCTAssertTrue(GlobalState.globalAttributes.isEmpty)
+
+        GlobalState.addAttribute(forKey: "int", value: 42)
+        GlobalState.removeAttribute(key: "int")
+
+        XCTAssertTrue(GlobalState.globalAttributes.isEmpty)
+    }
+
+    func testAttributeRemovedViaNilValue() throws {
+        GlobalState.addAttribute(forKey: "foo", value: "bar")
+        GlobalState.addAttribute(forKey: "foo", value: nil)
+
+        XCTAssertTrue(GlobalState.globalAttributes.isEmpty)
+
+        GlobalState.addAttribute(forKey: "int", value: 42)
+        GlobalState.addAttribute(forKey: "int", value: nil)
+
+        XCTAssertTrue(GlobalState.globalAttributes.isEmpty)
+    }
+
+    func testMergeWithGlobalAttributes() throws {
+        let attributes: [String: Encodable] = [
+            "foo": "foobar",
+            "another_int": 1_337
+        ]
+
+        GlobalState.addAttribute(forKey: "foo", value: "bar")
+        GlobalState.addAttribute(forKey: "int", value: 42)
+
+        let merged = attributes.mergeWithGlobalAttributes()
+
+        XCTAssertEqual(merged["foo"] as? String, "foobar")
+        XCTAssertEqual(merged["int"] as? Int, 42)
+        XCTAssertEqual(merged["another_int"] as? Int, 1_337)
+    }
+}


### PR DESCRIPTION
Implementation of similar PR https://github.com/DataDog/dd-bridge-android/pull/30 which was done in Android bridge repo before. The goal of this change is to propagate global attributes which are set with `DdSdk#setAttributes` in the hybrid layer also to the Spans and Logs, not only to RUM.