### PR TITLE
RUMM-1601 Use the `_dd.long_task.threshold` attribute (in milliseconds)

### DIFF
--- a/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
+++ b/DatadogSDKBridge/Classes/Implementation/DdSdkImplementation.swift
@@ -81,6 +81,11 @@ internal class DdSdkImplementation: DdSdk {
             _ = ddConfigBuilder.set(serviceName: serviceName)
         }
 
+        if let threshold = additionalConfig?["_dd.long_task.threshold"] as? TimeInterval {
+            // `_dd.long_task.threshold` attribute is in milliseconds
+            _ = ddConfigBuilder.trackRUMLongTasks(threshold: threshold / 1_000)
+        }
+
         if let proxyConfiguration = buildProxyConfiguration(config: additionalConfig) {
             _ = ddConfigBuilder.set(proxyConfiguration: proxyConfiguration)
         }

--- a/Example/Tests/DdSdkTests.swift
+++ b/Example/Tests/DdSdkTests.swift
@@ -257,6 +257,23 @@ internal class DdSdkTests: XCTestCase {
         XCTAssertEqual(trackingConsent, TrackingConsent.pending)
     }
 
+    func testBuildLongTaskThreshold() {
+        let configuration = DdSdkConfiguration(
+            clientToken: "client-token",
+            env: "env",
+            applicationId: "app-id",
+            nativeCrashReportEnabled: true,
+            sampleRate: 75.0,
+            site: nil,
+            trackingConsent: "pending",
+            additionalConfig: ["_dd.long_task.threshold": 2_500]
+        )
+
+        let ddConfig = DdSdkImplementation().buildConfiguration(configuration: configuration)
+
+        XCTAssertEqual(ddConfig.rumLongTaskDurationThreshold, 2.5)
+    }
+
     func testBuildProxyConfiguration() {
         let configuration: NSMutableDictionary = [
             "_dd.proxy.address": "host",


### PR DESCRIPTION
### What and why?

Use the `_dd.long_task.threshold` attribute (in milliseconds)